### PR TITLE
dependency correction

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "babel-core": "^5.5.8",
     "babel-loader": "^5.1.4",
-    "css-loader": "^0.14.5",
+    "css-loader": "^0.15.4",
     "html-loader": "^0.3.0",
     "jade": "^1.11.0",
     "style-loader": "^0.12.3",


### PR DESCRIPTION
npm ERR! peerinvalid The package css-loader does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer vue-loader@2.1.1 wants css-loader@^0.15.4