### PR TITLE
Deprecation warning and link to vue-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# vue-loader example
+# vue-loader example (deprecated)
+
+Deprecated in favor of [vue-cli](https://github.com/vuejs/vue-cli) and [webpack vue-cli template](https://github.com/vuejs-templates/webpack).
 
 [![Dependencies](https://img.shields.io/david/vuejs/vue-loader-example.svg?style=flat-square)](https://david-dm.org/vuejs/vue-loader-example)
 [![Dev Dependencies](https://img.shields.io/david/dev/vuejs/vue-loader-example.svg?style=flat-square)](https://david-dm.org/vuejs/vue-loader-example#info=devDependencies)


### PR DESCRIPTION
I think it doesn't make sense to maintain this example now that we have https://github.com/vuejs/vue-cli and https://github.com/vuejs-templates/webpack.

What do you think?

Proposal B, if deprecation isn't something we'd like to do:

Just add links to `vue-cli` and `webpack template` to the readme to show that better `starterkit` exists?