### PR TITLE
fix sourcce-map Deprecation warning on chrome

### DIFF
--- a/build/webpack.dev.config.js
+++ b/build/webpack.dev.config.js
@@ -1,6 +1,6 @@
 var config = require('./webpack.base.config')
 
-config.devtool = 'eval-source-map'
+config.devtool = '#eval-source-map'
 
 config.devServer = {
   noInfo: true


### PR DESCRIPTION
在chrome，firefox的新版本中，vue-loader-example的dev模式默认的source-map生成
会导致大量warning
![image](https://cloud.githubusercontent.com/assets/5762459/13519694/c7d013d0-e214-11e5-900c-eda606dd9870.png)

>  '//@ sourceURL' and '//@ sourceMappingURL' are deprecated, please use '//# sourceURL=' and '//# sourceMappingURL=' instead.

按照webpack文档的说法应该在`eval-source-map`前添加#，启用不同的前戳
